### PR TITLE
Add mutation instrumentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ failure = "0.1.8"
 seq-macro = "0.1.5"
 ed-derive = "0.1.1"
 
+[dev-dependencies]
+mutagen = {git = "https://github.com/llogiq/mutagen"}
+
 [profile.bench]
 lto = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,13 +812,13 @@ mod tests {
     fn test_box_encode_into() {
         let test = Box::new(42);
         let mut vec = vec![12];
-        test.encode_into(&mut vec);
+        test.encode_into(&mut vec).unwrap();
         assert_eq!(*test, 42);
     }
 
     #[test]
     fn test_box_decode() {
-        let mut bytes = vec![1];
+        let bytes = vec![1];
         let test = Box::new(bytes.as_slice());
         let decoded_value: Box<bool> = Decode::decode(test).unwrap();
         assert_eq!(*decoded_value, true);
@@ -827,7 +827,7 @@ mod tests {
     #[test]
     fn test_box_decode_into() {
         let mut test = Box::new(false);
-        let mut bytes = vec![1];
+        let bytes = vec![1];
         test.decode_into(bytes.as_slice()).unwrap();
         assert_eq!(*test, true);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,6 +812,15 @@ mod tests {
     }
 
     #[test]
+    fn test_vec_encoding_length() {
+        let forty_two: u8 = 42;
+        let mut vec: Vec<u8> = vec![42, 42, 42];
+        let vec_length = vec.encoding_length().unwrap();
+        let indv_num_length = forty_two.encoding_length().unwrap();
+        assert!(vec_length == indv_num_length * 3);
+    }
+
+    #[test]
     fn test_box_encoding_length() {
         let forty_two = Box::new(42);
         let length = forty_two.encoding_length().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,6 +765,14 @@ mod tests {
     }
 
     #[test]
+    fn test_option_encoding_length() {
+        let val = 0x12u8;
+        let option = Some(val);
+        let option_length = option.encoding_length().unwrap();
+        let val_length = val.encoding_length().unwrap();
+        assert!(option_length == val_length + 1);
+    }
+    #[test]
     fn test_option_none_encode_into() {
         let option: Option<u8> = None;
         let mut vec: Vec<u8> = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -712,6 +712,12 @@ mod tests {
     }
 
     #[test]
+    fn test_encoding_length_bool() {
+        let value: bool = true;
+        let enc_length = value.encoding_length().unwrap();
+        assert!(enc_length == 1);
+    }
+    #[test]
     fn test_decode_bool_true() {
         let bytes = vec![1];
         let decoded_value: bool = Decode::decode(bytes.as_slice()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,6 +622,7 @@ impl<T: Decode> Decode for Box<T> {
 #[cfg(test)]
 use mutagen::mutate;
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,6 +773,13 @@ mod tests {
     }
 
     #[test]
+    fn test_option_none_encoding_length() {
+        let option: Option<u8> = None;
+        let length = option.encoding_length().unwrap();
+        assert!(length == 1);
+    }
+
+    #[test]
     #[should_panic(expected = "Unexpected byte 42")]
     fn test_bail_option_decode_into() {
         let mut option: Option<u8> = Some(42);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,6 @@ macro_rules! int_impl {
         impl Encode for $type {
             #[doc = "Encodes the integer as fixed-size big-endian bytes."]
             #[inline]
-            #[cfg_attr(test, mutate)]
             fn encode_into<W: Write>(&self, dest: &mut W) -> Result<()> {
                 let bytes = self.to_be_bytes();
                 dest.write_all(&bytes[..])?;
@@ -168,7 +167,6 @@ macro_rules! int_impl {
             #[doc = "Returns the size of the integer in bytes. Will always"]
             #[doc = " return an `Ok` result."]
             #[inline]
-            #[cfg_attr(test, mutate)]
             fn encoding_length(&self) -> Result<usize> {
                 Ok($length)
             }
@@ -177,7 +175,6 @@ macro_rules! int_impl {
         impl Decode for $type {
             #[doc = "Decodes the integer from fixed-size big-endian bytes."]
             #[inline]
-            #[cfg_attr(test, mutate)]
             fn decode<R: Read>(mut input: R) -> Result<Self> {
                 let mut bytes = [0; $length];
                 input.read_exact(&mut bytes[..])?;
@@ -334,7 +331,6 @@ macro_rules! tuple_impl {
             #[doc = "Encodes the fields of the tuple one after another, in"]
             #[doc = " order."]
             #[allow(non_snake_case, unused_mut)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn encode_into<W: Write>(&self, mut dest: &mut W) -> Result<()> {
                 let ($($type,)* $last_type,) = self;
@@ -346,7 +342,6 @@ macro_rules! tuple_impl {
             #[doc = " the tuple."]
             #[allow(non_snake_case)]
             #[allow(clippy::needless_question_mark)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn encoding_length(&self) -> Result<usize> {
                 let ($($type,)* $last_type,) = self;
@@ -361,7 +356,6 @@ macro_rules! tuple_impl {
             #[doc = "Decodes the fields of the tuple one after another, in"]
             #[doc = " order."]
             #[allow(unused_mut)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn decode<R: Read>(mut input: R) -> Result<Self> {
                 Ok((
@@ -375,7 +369,6 @@ macro_rules! tuple_impl {
             #[doc = ""]
             #[doc = "Recursively calls `decode_into` for each field."]
             #[allow(non_snake_case, unused_mut)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn decode_into<R: Read>(&mut self, mut input: R) -> Result<()> {
                 let ($($type,)* $last_type,) = self;
@@ -403,7 +396,6 @@ macro_rules! array_impl {
             #[doc = "Encodes the elements of the array one after another, in"]
             #[doc = " order."]
             #[allow(non_snake_case, unused_mut, unused_variables)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn encode_into<W: Write>(&self, mut dest: &mut W) -> Result<()> {
                 for element in self[..].iter() {
@@ -414,7 +406,6 @@ macro_rules! array_impl {
 
             #[doc = "Returns the sum of the encoding lengths of all elements."]
             #[allow(non_snake_case)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn encoding_length(&self) -> Result<usize> {
                 let mut sum = 0;
@@ -429,7 +420,6 @@ macro_rules! array_impl {
             #[doc = "Decodes the elements of the array one after another, in"]
             #[doc = " order."]
             #[allow(unused_variables, unused_mut)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn decode<R: Read>(mut input: R) -> Result<Self> {
                 seq!(N in 0..$length {
@@ -445,7 +435,6 @@ macro_rules! array_impl {
             #[doc = ""]
             #[doc = "Recursively calls `decode_into` for each element."]
             #[allow(clippy::reversed_empty_ranges)]
-            #[cfg_attr(test, mutate)]
             #[inline]
             fn decode_into<R: Read>(&mut self, mut input: R) -> Result<()> {
                 for i in 0..$length {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,4 +858,11 @@ mod tests {
         let size = slice.encoding_length().unwrap();
         assert_eq!(size, 12);
     }
+
+    #[test]
+    fn test_unit_encoding_length() {
+        let unit = ();
+        let length = unit.encoding_length().unwrap();
+        assert!(length == 0);
+    }
 }


### PR DESCRIPTION
Brings mutation score to 84.85% on currently instrumented functions. Macros were left out because of infeasible number of tests required to kill mutants at each defined array size. Will add additional mutation instrumentation and tests after const generic refactor.